### PR TITLE
Trim the whitespace when parsing the object cards csv

### DIFF
--- a/server/src/objects/Game.ts
+++ b/server/src/objects/Game.ts
@@ -95,7 +95,11 @@ export class Game {
 			.then((data) => {
 				let objects: object_deck[] = [];
 				for (var line of data) {
-					objects.push(Object.values(line));
+					objects.push(
+						Object.values(line).map(
+							object_string => object_string.trim()
+						)
+					);
 				};
 				this._objects = new Deck(objects);
 			})


### PR DESCRIPTION
Hey Oliver,

you might remember me, we briefly talked on the Ghost Writer Kickstarter about your implementation of this game (great job btw). I did manage to set this game up on my server with a few tries, your documentation was pretty good.

I already played the game with some friends and it's great. However, we noticed something that we first thought was a bug. Sometimes it worked as expected, we entered the correct word, the input field turned green and we got the return to lobby button, but more often than not, it didn't. I thought it's a bug, but then I realised, out of habit I entered the objects into the csv as follows: 

```
Object1, Object2, Object3, Object4, Object5, Object6
```

The problem with that was, that the answer for the second to the sixth object wasn't "Object2" but " Object2" with a leading whitespace, hence the string comparison returned false. This was of course entirely my fault, but I thought it doesn't hurt to make the code a little more robust in this regard.

What do you think? Let me know if you don't like the code formatting or the variable name, I can change easly. I can be somewhat picky about stuff like that in my own code, so I would understand ; )

Regards,
Jan